### PR TITLE
chore(OPS-679): Backing up repository to Cloudflare

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - mgiles-cloudflare-backup
 jobs:
   back-up:
     runs-on: ubuntu-22.04

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,22 +1,37 @@
-name: Mirror repo to S3
+name: Backup GitHub Repository to Cloudflare R2 Bucket
+
 on:
   push:
     branches:
       - master
+      - mgiles-cloudflare-backup
 jobs:
-  s3Backup:
-    runs-on: ubuntu-latest
+  back-up:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        repo:
+          [
+            "github.com/LucidumInc/update-manager.git",
+          ]
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch      
-      - name: S3 Backup
-        uses: peter-evans/s3-backup@v1
-        env:
-          ACCESS_KEY_ID: ${{ secrets.S3_BACKUP_ACCESSKEY }}
-          SECRET_ACCESS_KEY: ${{ secrets.S3_BACKUP_SECRET }}
-          MIRROR_TARGET: lucidum-github-backup/${{ github.event.repository.name }}/${{ steps.extract_branch.outputs.branch }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          args: --overwrite --remove
+          node-version: "lts/*"
+
+      - name: Install @larose/git-backup
+        run: npm install -g @larose/git-backup
+
+      - name: Backing up repository ${{ github.event.repository.name }}
+        run: |
+          git-backup snapshot \
+            --repo https://${{ secrets.BACKUP_PAT }}@${{ matrix.repo }} \
+            --remote ${{ secrets.BACKUP_LOCATION }}/${{ github.event.repository.name }}/${{ github.ref_name }} \
+            --access-key-id ${{ secrets.BACKUP_ACCESS_KEY_ID }} \
+            --secret-access-key ${{ secrets.BACKUP_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-20.04 ]
         python-version: [ 3.6, 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-18.04 ]
         python-version: [ 3.6, 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates the `Backup` GitHub Action to ensure backups of relevant release branches, and `master` and stored in a Cloudflare R2 bucket instead of AWS. The storage path of each backup adheres to the following format:

`{Cloudflare-R2-Bucket-Name}/{repository-name}/{Branch}/`

Below is a screenshot of the development branch being pushed as a tar file to Cloudflare.
![image](https://github.com/user-attachments/assets/bce0f7be-9208-45d0-9d3a-da6bcb4b2cfc)