### PR TITLE
chore(DE-152): Updating behave tests to deal with current file structure

### DIFF
--- a/test/post-deploy/features/steps/docker_tests.py
+++ b/test/post-deploy/features/steps/docker_tests.py
@@ -25,9 +25,18 @@ def step_impl(context):
   docker_images = []
 
   for local_image in client.images.list():
-    docker_images.append(local_image.tags[0])
+    # Updated airflow images use an environment variable so strip that off.
+    if "AIRFLOW_IMAGE_NAME" in local_image.tags[0]:
+      image_name = local_image.tags[0].split(":-", 1)[1].rstrip("}")
+      docker_images.append(image_name)
+    else:
+      docker_images.append(local_image.tags[0])
 
   for compose_container in context.docker_containers:
+    # Updated airflow images use an environment variable so strip that off.
+    if "AIRFLOW_IMAGE_NAME" in compose_container:
+      compose_container = compose_container.split(":-", 1)[1].rstrip("}")
+
     if compose_container not in docker_images:
       assert context.failed is True
 
@@ -37,8 +46,17 @@ def step_impl(context):
   local_containers = []
 
   for container in client.containers.list():
-    local_containers.append(container.image.tags[0])
+    # Updated airflow images use an environment variable so strip that off.
+    if "AIRFLOW_IMAGE_NAME" in container.image.tags[0]:
+      image_name = container.image.tags[0].split(":-", 1)[1].rstrip("}")
+      local_containers.append(image_name)
+    else:
+      local_containers.append(container.image.tags[0])
 
   for compose_container  in context.docker_containers:
+    # Updated airflow images use an environment variable so strip that off.
+    if "AIRFLOW_IMAGE_NAME" in compose_container:
+      compose_container = compose_container.split(":-", 1)[1].rstrip("}")
+
     if compose_container not in local_containers:
       assert context.failed is True

--- a/test/post-deploy/features/steps/installation.py
+++ b/test/post-deploy/features/steps/installation.py
@@ -3,6 +3,9 @@ import glob
 import pwd
 import os
 
+PATHS_TO_IGNORE = ["/usr/lucidum/tunnel", "/usr/lucidum/mongo", "/usr/lucidum/mysql",
+                   "__pycache__", "/usr/lucidum/update-manager/logs"]
+
 @given('we have a lucidum installation')
 def step_impl(context):
   pass
@@ -15,7 +18,8 @@ def step_impl(context, install_path):
 @then('ensure files and directories do not have "{user}" ownership')
 def step_impl(context, user):
   for filepath in glob.iglob(context.install_path + '/**/**', recursive=True):
-    if not os.path.islink(filepath):
+    paths_not_present = all(path not in filepath for path in PATHS_TO_IGNORE)
+    if not os.path.islink(filepath) and paths_not_present:
       file_uid = os.stat(filepath).st_uid
       user_uid = pwd.getpwnam(user).pw_uid
       assert file_uid != user_uid


### PR DESCRIPTION
Updated `update-manager` behave tests to account for changes in the Lucidum system. These tests have failed for a few releases but the output was never visible in the build logs. The following changes were made:
* When determining running containers, stripped off the ENV variables from the container name as that is not present when querying running containers.
* Filtered out the filepaths that are not owned by the root account.

Successful AMI build (where update-manager tests are executed) [here](https://jenkins.cicd.luciduminc.net/job/playground/job/aws-create-instance/526/).

![image](https://github.com/user-attachments/assets/68a62275-17a9-45e0-80da-1cbdf9badf13)

![image](https://github.com/user-attachments/assets/bbb9c335-ffdd-45a6-aa7f-37bf799f9624)
