### PR TITLE
chore(UM-2): Add storage utilization to healthcheck API

### DIFF
--- a/healthcheck_handler.py
+++ b/healthcheck_handler.py
@@ -68,6 +68,8 @@ def get_disk_usage(path: str) -> dict:
         value = getattr(data, name)
         if name != "percent":
             value = bytes2human(value)
+        else:
+            value = f"{value}%"
         disk[name] = value
     return disk
 
@@ -222,7 +224,7 @@ class DiskUsageInfoCollector(SystemInfoCollector):
 
     def __call__(self):
         disk = get_disk_usage("/")
-        return disk["total"]
+        return [f"{key}: {value}" for key, value in disk.items()]
 
 
 class CPUUsageInfoCollector(SystemInfoCollector):


### PR DESCRIPTION
Added the following storage details to `update-manager/api/healthcheck/system`:

* `total` (was already there but the only value - see screenshots below)
* `used`
* `free`
* `percent`

**Screenshot of the _Old_ Output:**

![healthcheck-output-old](https://github.com/user-attachments/assets/0a1b6b8f-6e56-4fb4-8ba6-3daf0a4b4577)


**Screenshot of the _New_ Output:**

![healthcheck-output-new](https://github.com/user-attachments/assets/d287805e-3468-4fa7-a5a0-076e4529dbd6)

