### PR TITLE
chore(DE-205): update docker-compose for global-manager

### DIFF
--- a/install_handler.py
+++ b/install_handler.py
@@ -27,6 +27,7 @@ DOCKER_COMPOSE_SERVICE_IMAGE_MAPPING = {
     "web": "mvp1_backend",
     "connector-api": "connector-api",
     "action-manager": "action-manager",
+    "global-manager": "global-manager",
 }
 
 # airflow only if image name is different from service name

--- a/install_handler.py
+++ b/install_handler.py
@@ -28,6 +28,7 @@ DOCKER_COMPOSE_SERVICE_IMAGE_MAPPING = {
     "connector-api": "connector-api",
     "action-manager": "action-manager",
     "global-manager": "global-manager",
+    "nginx": "nginx",
 }
 
 # airflow only if image name is different from service name


### PR DESCRIPTION
Allow `update-manager` to update the `global-manager` and `nginx` images on MoM deployments.