### PR TITLE
chore(CM-12): Adding CM images to update-manager install

### DIFF
--- a/install_handler.py
+++ b/install_handler.py
@@ -28,6 +28,8 @@ DOCKER_COMPOSE_SERVICE_IMAGE_MAPPING = {
     "connector-api": "connector-api",
     "action-manager": "action-manager",
     "global-manager": "global-manager",
+    "customer-manager": "customer-manager",
+    "cve-api": "cve-api",
     "nginx": "nginx",
 }
 


### PR DESCRIPTION
Updates to allow the installation of the `customer-manager` and `cve-api` docker images on Customer Manager.