### PR TITLE
chore(UM-8): Snyk updates for Tortoise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiocontextvars==0.2.2
-botocore==1.37.34
-boto3==1.37.34
-awscli==1.38.34
+botocore==1.42.47
+boto3==1.42.47
+awscli==1.44.37
 cffi==1.17.1
 chardet==4.0.0
 click==7.1.2
@@ -23,7 +23,7 @@ pymongo==4.12.0
 python-dateutil==2.8.1
 PyYAML==6.0.2
 rsa==4.7.2
-s3transfer==0.11.0
+s3transfer==0.16.0
 six==1.17.0
 tabulate==0.8.9
 urllib3==2.6.3


### PR DESCRIPTION
**This PR performs the following:**
* Updated `awscli` to version `1.44.37` to resolve a Snyk CVE.
  * Updated `botocore` to version `1.42.47` due to the `awscli` version update.
  * Updated `boto3` to version `1.42.47` due to the `awscli` version update.
  * Updated `s3transfer` to version `0.16.0` due to the `awscli` version update.

NOTE: Just keeping the repositories in sync. The actual Snyk fixes are applied in the following ansible-playbooks https://github.com/LucidumInc/ansible-playbooks/pull/570.

**Successful AMI Builds:**
* `Lucidum AMI Build`: [here](https://jenkins.cicd.luciduminc.net/job/playground/job/aws-create-instance/1156/).
* `Airflow AMI Build`: [here](https://jenkins.cicd.luciduminc.net/job/playground/job/aws-create-airflow-instance/104/).
* `MoM AMI Build`: [here](https://jenkins.cicd.luciduminc.net/job/playground/job/aws-create-global-manager-instance/203/).
* `Luci AMI Build`: [here](https://jenkins.cicd.luciduminc.net/job/playground/job/aws-create-luci-instance/51/).