### PR TITLE
chore(UM-9): Snyk fixes for the Bigfoot release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jmespath==0.10.0
 loguru==0.7.2
 MarkupSafe==3.0.2
 pip==26.0.1
-pyasn1==0.6.2
+pyasn1==0.6.3
 pycparser==2.20
 pymongo==4.12.0
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.6
 contextvars==2.4
 docker==7.1.0
 docutils==0.19
-dynaconf==3.1.4
+dynaconf==3.2.13
 idna==3.7
 immutables==0.21
 Jinja2==3.1.6
@@ -28,7 +28,7 @@ six==1.17.0
 tabulate==0.8.9
 urllib3==2.6.3
 websocket-client==0.58.0
-pydantic==1.10.19
+pydantic==2.10.4
 uvicorn==0.13.4
 gunicorn==23.0.0
 aiofiles==0.6.0


### PR DESCRIPTION
Bumping the version of 3rd party library `pyasn1`: `0.6.2` -> `0.6.3` and `dynaconf`: `3.1.4` -> `3.2.13`. Also updated the `pydantic` version to match the version in the ansible-playbooks repo.

Successful AMI Build: [here](https://jenkins.cicd.luciduminc.net/job/playground/job/aws-create-instance/1182/).